### PR TITLE
Slack alerting tick scripts

### DIFF
--- a/gtikk-charts/kapacitor/TICKscripts/stream/container_status.tick
+++ b/gtikk-charts/kapacitor/TICKscripts/stream/container_status.tick
@@ -1,0 +1,16 @@
+dbrp "telegraf"."autogen"
+
+stream
+	|from()
+		.measurement('docker_container_status')
+		.groupBy('container_name')
+	|window()
+		.period(1m)
+		.every(1m)
+	|alert()
+		.warn(lambda: "container_status" != 'running')
+	.message('Docker Container {{index .Tags "container_name" }} is not running')
+	.slack()
+	.stateChangesOnly()
+
+	

--- a/gtikk-charts/kapacitor/TICKscripts/stream/failed_pod_alert.tick
+++ b/gtikk-charts/kapacitor/TICKscripts/stream/failed_pod_alert.tick
@@ -1,0 +1,16 @@
+dbrp "telegraf"."autogen"
+
+stream
+	|from()
+		.measurement('kube_pod_status_phase')
+		.groupBy('pod')
+	|window()
+		.period(1m)
+		.every(1m)
+	|alert()
+		.warn(lambda: "phase" == 'Failed' AND "gauge" == int(1))
+	.message('warning: Pod {{ index .Tags "pod"}} is not running')
+	.slack()
+	.stateChangesOnly()
+
+	

--- a/gtikk-charts/kapacitor/TICKscripts/stream/node_status.tick
+++ b/gtikk-charts/kapacitor/TICKscripts/stream/node_status.tick
@@ -1,0 +1,16 @@
+dbrp "telegraf"."autogen"
+
+stream
+	|from()
+		.measurement('kube_node_status_condition')
+		.groupBy('host','condition')
+	|window()
+		.period(1m)
+		.every(1m)
+	|alert()
+		.warn(lambda: "condition" != 'Ready' AND "gauge" == int(1) AND "status" == 'true')
+	.message('warning: Node {{ index .Tags "host"}} is showing status: {{ index .Tags "condition"}}')
+	.slack()
+	.stateChangesOnly()
+
+	

--- a/gtikk-charts/kapacitor/TICKscripts/stream/slack_alert.tick
+++ b/gtikk-charts/kapacitor/TICKscripts/stream/slack_alert.tick
@@ -1,0 +1,11 @@
+dbrp "telegraf"."autogen"
+
+stream
+	|from()
+		.measurement('cpu')
+	|alert()
+		.warn(lambda: int("usage_idle") < 100)
+	.message('cpu test')
+	.slack()
+	.iconEmoji(':exclamation:')
+	

--- a/gtikk-charts/kapacitor/influx_queries.txt
+++ b/gtikk-charts/kapacitor/influx_queries.txt
@@ -1,0 +1,22 @@
+select "time","gauge","pod" 
+from "kube_pod_status_phase" 
+where "phase" = 'Failed' and "gauge" = 1 and time > now() - 60s 
+tz('America/Los_Angeles')
+
+select "pid","container_name","container_status" 
+from "docker_container_status" where "container_status" <> 'running'
+
+select "pid","container_name","container_status" 
+from "docker_container_status" where "container_status" = 'running' 
+and gauge = 1 limit 20
+
+
+select *  from "kube_node_status_condition" limit 1
+
+select distinct('condition') 
+from (select "condition","gauge" from "kube_node_status_condition") limit 10
+
+show field keys
+show tag keys
+show measurements
+show retention policies

--- a/gtikk-charts/kapacitor/templates/config.yaml
+++ b/gtikk-charts/kapacitor/templates/config.yaml
@@ -34,7 +34,7 @@ data:
       enabled = true
       name = "default"
       default = false
-      urls = [{{ .Values.influxURL | quote }}]
+      urls = ["http://{{ template "fullname" . }}.{{.Release.Namespace}}:8086"]
       username = ""
       password = ""
       ssl-ca = ""

--- a/gtikk-charts/kapacitor/templates/config.yaml
+++ b/gtikk-charts/kapacitor/templates/config.yaml
@@ -34,7 +34,7 @@ data:
       enabled = true
       name = "default"
       default = false
-      urls = ["http://{{ template "fullname" . }}.{{.Release.Namespace}}:8086"]
+      urls = [{{ .Values.influxURL | quote }}]
       username = ""
       password = ""
       ssl-ca = ""
@@ -135,12 +135,11 @@ data:
       enabled = true
       default = true
       workspace = "skytap-cronus.slack.com"
-      url = "https://hooks.slack.com/services/TCNH23GCU/BDXJMNA/Ae40cl3u9QLZ4M4wA6BtJ9ZQ"
+      url = "https://hooks.slack.com/services/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"
       channel = "#kapacitorspam"
       username = "kapacitor"
       global = false
       state-changes-only = false
-      insecure-skip-verify = false
     [talk]
       enabled = false
       url = ""


### PR DESCRIPTION
add a few tick scripts for slack alerts, haven't tested them a whole lot so there might be some errors but as far as I can tell they work. also added a .txt file with some influxDB queries to help get a feel of the DB schema since it is a bit confusing to navigate at first. I'll add more as I continue with more alerts. Also edited the config file in the yaml deployment so all you need to do is run destroy.sh and create.sh and it will be set up for slack alerts. also not sure what's going on with line 37 or the config file, check that out before merging.